### PR TITLE
Add clone() methods to AsepriteSpriteSheet and AsepriteResource

### DIFF
--- a/src/AsepriteResource.ts
+++ b/src/AsepriteResource.ts
@@ -60,7 +60,7 @@ export class AsepriteResource implements Loadable<AsepriteSpriteSheet> {
         clone.rawAseprite = this.rawAseprite;
         clone.image = this.image;
 
-        return clone
+        return clone;
     }
 
     isLoaded(): boolean {

--- a/src/AsepriteResource.ts
+++ b/src/AsepriteResource.ts
@@ -54,6 +54,14 @@ export class AsepriteResource implements Loadable<AsepriteSpriteSheet> {
         }
     }
 
+    public clone() {
+        const clone = new AsepriteResource(this._resource.path, this.bustCache);        
+        clone.data = this.data.clone();
+        clone.rawAseprite = this.rawAseprite;
+        clone.image = this.image;
+
+        return clone
+    }
 
     isLoaded(): boolean {
         return !!this.data;

--- a/src/AsepriteSpriteSheet.ts
+++ b/src/AsepriteSpriteSheet.ts
@@ -73,4 +73,8 @@ export class AsepriteSpriteSheet {
         }
         return this._animations.get(name) as Animation;
     }
+
+    clone() {
+        return new AsepriteSpriteSheet(this.asepriteRaw, this.image);
+    }
 }

--- a/test/unit/AsepriteResource.spec.ts
+++ b/test/unit/AsepriteResource.spec.ts
@@ -47,4 +47,18 @@ describe('An Aseprite Resource', () => {
         expect(spriteSheet?.getSprite(0, 0)?.width).toBe(64);
         expect(spriteSheet?.getSprite(0, 0)?.height).toBe(64);
     });
+
+    it ('can clone', async () => {
+        const sut = new AsepriteResource('test/unit/beetle.json');
+        await sut.load();
+
+        const clone = sut.clone();
+
+        expect(sut).not.toBe(clone);
+        expect(clone).toBeDefined();
+        expect(clone.isLoaded()).toBe(true);
+        expect(clone.rawAseprite).toBe(sut.rawAseprite);
+        expect(clone.image).toBe(sut.image);
+        expect(clone.data).toBeDefined();    
+    })
 });

--- a/test/unit/AsepriteSpriteSheet.spec.ts
+++ b/test/unit/AsepriteSpriteSheet.spec.ts
@@ -68,4 +68,41 @@ describe('An AsepriteSpriteSheet Parser', () => {
         expect(frame1OfAnim3.sourceView.x).toBe(0);
         expect(anim3.strategy).toBe(AnimationStrategy.PingPong);
     });
+
+    it('can clone', () => {
+        const raw: AsepriteRaw = {
+            meta: {
+                image: './path/to/image',
+                size: { w: 20, h: 20 },
+                scale: 1,
+                format: 'RGBA8888',
+                layers: [],
+                frameTags: [
+                    { name: "anim1", from: 0, to: 1, direction: "forward"},
+                ],
+                slices: []
+            },
+            frames: {
+                "frame1": {
+                    frame: { x: 0, y: 0, w: 10, h: 10},
+                    rotated: false,
+                    trimmed: false,
+                    spriteSourceSize: { x: 0, y: 0, w: 10, h: 10 },
+                    sourceSize: { w: 10, h: 10 },
+                    duration: 500
+                }
+            }
+        }
+
+
+        const aseprite = new AsepriteSpriteSheet(raw, new ImageSource('./path/to/some/image'));
+
+        const clone = aseprite.clone();
+
+        expect(clone).toBeDefined();
+        expect(clone).not.toBe(aseprite);
+        expect(aseprite.asepriteRaw).toEqual(clone.asepriteRaw);
+        expect(aseprite.image).toEqual(clone.image);
+        expect(clone.getAnimation('anim1')).not.toBe(aseprite.getAnimation('anim1'));
+    })
 });


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #126

## Changes:

- Added `clone()` method to `AsepriteSpriteSheet`
- Added `clone()` method to `AsepriteResource`

--------------

The integration tests are failing for me on main:

```
Test: A Aseprite parsed resource
        Expect: Aseprite Loop Animation
[ERROR]: Image ./test/integration/images/expected.png did not match acutal ./test/integration/images/actual.png, 146 different!
```

but unit tests all pass.

I'm also willing to revert the commits for adding clone to `AsepriteResource`, but if we're okay with how it's implemented, I quite like having it. Cloning the resource over digging into the spritesheet/anims is much cleaner in usage.