### PR TITLE
Set default AnimationStrategy for AsepriteNativeParser to Loop

### DIFF
--- a/src/AsepriteNativeParser.ts
+++ b/src/AsepriteNativeParser.ts
@@ -93,10 +93,8 @@ export class AsepriteNativeParser {
         const frames = this._exFrames.slice(animationTag.from, animationTag.to + 1);
 
         const type = animationTag.type;
-        let strategy = AnimationStrategy.End;
-        if (type === AnimationTypes.Forward) {
-            strategy = AnimationStrategy.End;
-        } else if (type === AnimationTypes.PingPong || type === AnimationTypes.PingPongReverse) {
+        let strategy = AnimationStrategy.Loop;
+        if (type === AnimationTypes.PingPong || type === AnimationTypes.PingPongReverse) {
             strategy = AnimationStrategy.PingPong;
         }
 

--- a/test/unit/AsepriteNativeParser.spec.ts
+++ b/test/unit/AsepriteNativeParser.spec.ts
@@ -38,7 +38,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 
@@ -65,7 +65,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 
@@ -92,7 +92,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 
@@ -119,7 +119,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 
@@ -146,7 +146,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 
@@ -173,7 +173,7 @@ describe('A AsepriteNativeParser', () => {
 
         const otherAnim = nativeParser.getAnimation('Animation 2');
         expect(otherAnim.frames.length).toBe(2);
-        expect(otherAnim.strategy).toBe(AnimationStrategy.End);
+        expect(otherAnim.strategy).toBe(AnimationStrategy.Loop);
         expect(otherAnim.width).toBe(64);
         expect(otherAnim.height).toBe(64);
 


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

Closes #200 

## Changes:

- Set default AnimationStrategy for AsepriteNativeParser to Loop for Aseprite animation tags whose direction/type is Forward
